### PR TITLE
Add performance features for low-end devices

### DIFF
--- a/build_ninja.sh
+++ b/build_ninja.sh
@@ -15,9 +15,15 @@
 #                                   cmake libsdl2-dev:armhf
 #   Pass --armhf flag: ./build_pc.sh --armhf
 #
+# Linux AArch64 (64-bit ARM):
+#   Prerequisites: sudo dpkg --add-architecture arm64 && sudo apt update
+#                  sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
+#                                   cmake libsdl2-dev:arm64
+#   Pass --arm64 flag: ./build_pc.sh --arm64
+#
 # Usage:
-#   1. ./build_pc.sh [--armhf]
-#   2. Place your disc image (.ciso/.iso/.gcm) in pc/build32/bin/rom/
+#   1. ./build_pc.sh [--armhf|--arm64]
+#   2. Place your disc image (.ciso/.iso/.gcm) in pc/build32/bin/rom/ (or build64/)
 #   3. Run: pc/build32/bin/AnimalCrossing[.exe]
 
 set -e
@@ -28,6 +34,7 @@ USE_GLES=""
 for arg in "$@"; do
     case "$arg" in
         --armhf) ARCH="armhf" ;;
+        --arm64) ARCH="arm64" ;;
         --gles)  USE_GLES="-DPC_USE_GLES=ON" ;;
         *) echo "Unknown argument: $arg"; exit 1 ;;
     esac
@@ -46,7 +53,11 @@ else
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-BUILD_DIR="$SCRIPT_DIR/pc/build32"
+if [ "$ARCH" = "arm64" ]; then
+    BUILD_DIR="$SCRIPT_DIR/pc/build64"
+else
+    BUILD_DIR="$SCRIPT_DIR/pc/build32"
+fi
 BIN_DIR="$BUILD_DIR/bin"
 
 mkdir -p "$BUILD_DIR"
@@ -77,11 +88,36 @@ elif [ "$ARCH" = "armhf" ]; then
         export PKG_CONFIG=arm-linux-gnueabihf-pkg-config
     fi
 
-    if [ ! -f Makefile ]; then
+    if [ ! -f CMakeCache.txt ]; then
         echo "=== Configuring CMake (Linux ARMhf 32-bit) ==="
         cmake .. -G"Ninja" \
             -DCMAKE_TOOLCHAIN_FILE="../cmake/Toolchain-arm-linux-gnueabihf.cmake" \
 			-DCMAKE_PREFIX_PATH=/usr/opt/sdl2-armhf \
+            $USE_GLES
+    fi
+    echo "=== Building ==="
+    ninja
+
+elif [ "$ARCH" = "arm64" ]; then
+    # --- Linux AArch64 (cross-compile from x86_64) ---
+
+    # Help pkg-config find arm64 libraries on multiarch hosts.
+    for dir in \
+        /usr/lib/aarch64-linux-gnu/pkgconfig \
+        /usr/lib/pkgconfig; do
+        if [ -d "$dir" ]; then
+            export PKG_CONFIG_PATH="$dir:${PKG_CONFIG_PATH:-}"
+        fi
+    done
+
+    if command -v aarch64-linux-gnu-pkg-config &>/dev/null; then
+        export PKG_CONFIG=aarch64-linux-gnu-pkg-config
+    fi
+
+    if [ ! -f CMakeCache.txt ]; then
+        echo "=== Configuring CMake (Linux AArch64 64-bit) ==="
+        cmake .. -G "Ninja" \
+            -DCMAKE_TOOLCHAIN_FILE="../cmake/Toolchain-aarch64-linux-gnu.cmake" \
             $USE_GLES
     fi
     echo "=== Building ==="

--- a/include/PR/gbi.h
+++ b/include/PR/gbi.h
@@ -1159,7 +1159,11 @@ typedef struct {
  * First 8 words are integer portion of the 4x4 matrix
  * Last 8 words are the fraction portion of the 4x4 matrix
  */
+#ifdef TARGET_PC
+typedef s32	Mtx_t[4][4];
+#else
 typedef long	Mtx_t[4][4];
+#endif
 
 typedef union {
     Mtx_t		m;

--- a/pc/cmake/Toolchain-aarch64-linux-gnu.cmake
+++ b/pc/cmake/Toolchain-aarch64-linux-gnu.cmake
@@ -1,0 +1,25 @@
+# CMake toolchain file for Linux AArch64 (64-bit ARM)
+#
+# Requires:
+#   sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
+#                    libsdl2-dev:arm64
+#
+# On Debian/Ubuntu multiarch you may first need:
+#   sudo dpkg --add-architecture arm64
+#   sudo apt update
+
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+set(CMAKE_C_COMPILER   aarch64-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
+
+set(CMAKE_FIND_ROOT_PATH
+    /usr/lib/aarch64-linux-gnu
+    /usr/aarch64-linux-gnu
+    /usr
+)
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)   # build tools from host
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)    # libs from target (arm64)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)    # headers from target
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE BOTH)    # cmake package configs from either

--- a/pc/include/pc_settings.h
+++ b/pc/include/pc_settings.h
@@ -32,11 +32,8 @@ typedef struct {
     int frustum_cull;              /* 0=off, 1=on — PC uses horizontal distance from player, not GPU frustum */
     int frustum_cull_z_margin;     /* extra world units added to each actor's draw range; higher = less culling */
     int frustum_cull_max_distance; /* 0=no cap, else max XZ draw distance (world units); lower = more culling */
-    int actor_update_dist;      /* 0=off, else max XZ world units for non-NPC mv_proc */
-    int weather_particles;      /* 0=full, 1=reduced (half spawn rate), 2=off */
     int shadow_quality;         /* 0=all actors+world decals, 1=player only, 2=off (no shadows), 3=player+NPC */
     int reduce_acre_draw;       /* 0=full (up to 4 adjacent), 1=cross (orthogonal only), 2=current acre only */
-    int bg_anim_throttle;       /* 1=every frame, 2=half-rate, 4=quarter-rate */
 } PCSettings;
 
 extern PCSettings g_pc_settings;

--- a/pc/include/pc_settings.h
+++ b/pc/include/pc_settings.h
@@ -34,7 +34,7 @@ typedef struct {
     int frustum_cull_max_distance; /* 0=no cap, else max XZ draw distance (world units); lower = more culling */
     int actor_update_dist;      /* 0=off, else max XZ world units for non-NPC mv_proc */
     int weather_particles;      /* 0=full, 1=reduced (half spawn rate), 2=off */
-    int shadow_quality;         /* 0=all, 1=player only, 2=off */
+    int shadow_quality;         /* 0=all actors+world decals, 1=player only, 2=off (no shadows), 3=player+NPC */
     int reduce_acre_draw;       /* 0=3x3 (9 acres), 1=cross (5 acres) */
     int bg_anim_throttle;       /* 1=every frame, 2=half-rate, 4=quarter-rate */
 } PCSettings;

--- a/pc/include/pc_settings.h
+++ b/pc/include/pc_settings.h
@@ -20,7 +20,7 @@ typedef struct {
     int sfx_volume;       /* 0-100 */
     int voice_volume;     /* 0-100 */
     int zoom_enabled;     /* 0=off, 1=on */
-    int fps_target;       /* 0=60fps, 1=50fps, 2=40fps, 3=30fps, 4=20fps, 5=unlimited, 6=auto, 7=dynamic */
+    int fps_target;       /* 0=60fps, 1=50fps, 2=40fps, 3=30fps, 4=20fps, 5=unlimited, 6=dynamic */
     int render_scale;     /* render resolution %: 100, 75, 50, 25 */
     int window_size;      /* 0=320x240, 1=480x360, 2=640x480, 3=960x720, 4=1280x960, 5=custom */
     int scale_mode;       /* 0=stretch, 1=center (letterbox) */

--- a/pc/include/pc_settings.h
+++ b/pc/include/pc_settings.h
@@ -29,9 +29,9 @@ typedef struct {
     int right_deadzone;   /* right stick deadzone 0-50 (percent of axis range) */
     int swap_ab_xy;       /* 0=off, 1=on — swap A↔B and X↔Y on the hardcoded gamepad path */
     /* Performance (ARM64 low-spec) — all hot-toggled at runtime, no restart needed */
-    int frustum_cull;           /* 0=off, 1=on */
-    int frustum_cull_z_margin;  /* extra Z padding beyond cull_radius/distance; 0-200 world units */
-    int frustum_cull_x_margin;  /* X edge multiplier as 10ths: 10=1.0, 15=1.5, 20=2.0, 30=3.0 */
+    int frustum_cull;              /* 0=off, 1=on — PC uses horizontal distance from player, not GPU frustum */
+    int frustum_cull_z_margin;     /* extra world units added to each actor's draw range; higher = less culling */
+    int frustum_cull_max_distance; /* 0=no cap, else max XZ draw distance (world units); lower = more culling */
     int actor_update_dist;      /* 0=off, else max XZ world units for non-NPC mv_proc */
     int weather_particles;      /* 0=full, 1=reduced (half spawn rate), 2=off */
     int shadow_quality;         /* 0=all, 1=player only, 2=off */
@@ -40,6 +40,9 @@ typedef struct {
 } PCSettings;
 
 extern PCSettings g_pc_settings;
+
+/* Effective XZ cull radius when frustum_cull is on: min(cull_distance+cull_radius+margin, max) or uncapped max */
+float pc_settings_cull_limit_xz(float cull_distance, float cull_radius);
 
 void pc_settings_load(void);
 void pc_settings_save(void);

--- a/pc/include/pc_settings.h
+++ b/pc/include/pc_settings.h
@@ -27,6 +27,16 @@ typedef struct {
     int dpad_as_stick;    /* 0=off, 1=on — dpad directions also drive main stick */
     int left_deadzone;    /* left stick deadzone 0-50 (percent of axis range) */
     int right_deadzone;   /* right stick deadzone 0-50 (percent of axis range) */
+    int swap_ab_xy;       /* 0=off, 1=on — swap A↔B and X↔Y on the hardcoded gamepad path */
+    /* Performance (ARM64 low-spec) — all hot-toggled at runtime, no restart needed */
+    int frustum_cull;           /* 0=off, 1=on */
+    int frustum_cull_z_margin;  /* extra Z padding beyond cull_radius/distance; 0-200 world units */
+    int frustum_cull_x_margin;  /* X edge multiplier as 10ths: 10=1.0, 15=1.5, 20=2.0, 30=3.0 */
+    int actor_update_dist;      /* 0=off, else max XZ world units for non-NPC mv_proc */
+    int weather_particles;      /* 0=full, 1=reduced (half spawn rate), 2=off */
+    int shadow_quality;         /* 0=all, 1=player only, 2=off */
+    int reduce_acre_draw;       /* 0=3x3 (9 acres), 1=cross (5 acres) */
+    int bg_anim_throttle;       /* 1=every frame, 2=half-rate, 4=quarter-rate */
 } PCSettings;
 
 extern PCSettings g_pc_settings;

--- a/pc/include/pc_settings.h
+++ b/pc/include/pc_settings.h
@@ -35,7 +35,7 @@ typedef struct {
     int actor_update_dist;      /* 0=off, else max XZ world units for non-NPC mv_proc */
     int weather_particles;      /* 0=full, 1=reduced (half spawn rate), 2=off */
     int shadow_quality;         /* 0=all actors+world decals, 1=player only, 2=off (no shadows), 3=player+NPC */
-    int reduce_acre_draw;       /* 0=3x3 (9 acres), 1=cross (5 acres) */
+    int reduce_acre_draw;       /* 0=full (up to 4 adjacent), 1=cross (orthogonal only), 2=current acre only */
     int bg_anim_throttle;       /* 1=every frame, 2=half-rate, 4=quarter-rate */
 } PCSettings;
 

--- a/pc/src/pc_overlay.c
+++ b/pc/src/pc_overlay.c
@@ -67,7 +67,7 @@ enum {
     /* Perf tab */
     MI_FRUSTUM_CULL,
     MI_CULL_Z_MARGIN,
-    MI_CULL_X_MARGIN,
+    MI_CULL_MAX_DISTANCE,
     MI_ACTOR_UPDATE_DIST,
     MI_WEATHER_PARTICLES,
     MI_SHADOW_QUALITY,
@@ -98,9 +98,9 @@ static const char* menu_labels[MI_COUNT] = {
     [MI_LEFT_DEADZONE]   = "L-Stick Deadzone",
     [MI_RIGHT_DEADZONE]  = "R-Stick Deadzone",
     [MI_CTRL_RESET]      = "Reset Defaults",
-    [MI_FRUSTUM_CULL]       = "Frustum Cull",
-    [MI_CULL_Z_MARGIN]      = "Cull Z Margin",
-    [MI_CULL_X_MARGIN]      = "Cull X Margin",
+    [MI_FRUSTUM_CULL]       = "Distance cull",
+    [MI_CULL_Z_MARGIN]      = "Cull +range (units)",
+    [MI_CULL_MAX_DISTANCE]  = "Cull max dist (u)",
     [MI_ACTOR_UPDATE_DIST]  = "Actor Update Dist",
     [MI_WEATHER_PARTICLES]  = "Weather Particles",
     [MI_SHADOW_QUALITY]     = "Shadows",
@@ -143,7 +143,7 @@ static const int menu_item_tab[MI_COUNT] = {
     [MI_CTRL_RESET]      = TAB_CONTROLS,
     [MI_FRUSTUM_CULL]       = TAB_PERF,
     [MI_CULL_Z_MARGIN]      = TAB_PERF,
-    [MI_CULL_X_MARGIN]      = TAB_PERF,
+    [MI_CULL_MAX_DISTANCE]  = TAB_PERF,
     [MI_ACTOR_UPDATE_DIST]  = TAB_PERF,
     [MI_WEATHER_PARTICLES]  = TAB_PERF,
     [MI_SHADOW_QUALITY]     = TAB_PERF,
@@ -221,13 +221,12 @@ static void menu_get_value(int item, char* buf, int sz) {
     case MI_RIGHT_DEADZONE:  snprintf(buf, sz, "%d%%", g_pc_settings.right_deadzone); break;
     case MI_CTRL_RESET:      snprintf(buf, sz, "Press >"); break;
     case MI_FRUSTUM_CULL:    snprintf(buf, sz, "%s", g_pc_settings.frustum_cull ? "ON" : "OFF"); break;
-    case MI_CULL_Z_MARGIN:   snprintf(buf, sz, "%d", g_pc_settings.frustum_cull_z_margin); break;
-    case MI_CULL_X_MARGIN: {
-        static const char* xnames[] = {"Tight", "Normal", "Loose", "V.Loose"};
-        static const int   xvals[]  = {10, 15, 20, 30};
-        int cur = 1;
-        for (int i = 0; i < 4; i++) if (xvals[i] == g_pc_settings.frustum_cull_x_margin) { cur = i; break; }
-        snprintf(buf, sz, "%s", xnames[cur]);
+    case MI_CULL_Z_MARGIN:   snprintf(buf, sz, "+%d", g_pc_settings.frustum_cull_z_margin); break;
+    case MI_CULL_MAX_DISTANCE: {
+        if (g_pc_settings.frustum_cull_max_distance == 0)
+            snprintf(buf, sz, "Off (no cap)");
+        else
+            snprintf(buf, sz, "%d", g_pc_settings.frustum_cull_max_distance);
         break;
     }
     case MI_ACTOR_UPDATE_DIST: {
@@ -389,13 +388,22 @@ static void menu_adjust(int item, int dir) {
         g_pc_settings.frustum_cull_z_margin = v;
         break;
     }
-    case MI_CULL_X_MARGIN: {
-        static const int xvals[] = {10, 15, 20, 30};
-        int cur = 1;
-        for (int i = 0; i < 4; i++) if (xvals[i] == g_pc_settings.frustum_cull_x_margin) { cur = i; break; }
+    case MI_CULL_MAX_DISTANCE: {
+        /* 0 = uncapped; stepped caps so you can see culling in-game (lower = stricter). */
+        static const int caps[] = {
+            0, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000,
+            1100, 1200, 1300, 1400, 1500, 1600, 1700, 1800, 1900, 2000
+        };
+        int cur = 0;
+        for (int i = 0; i < (int)(sizeof caps / sizeof caps[0]); i++)
+            if (caps[i] == g_pc_settings.frustum_cull_max_distance) {
+                cur = i;
+                break;
+            }
         cur += dir;
-        if (cur < 0) cur = 3; if (cur > 3) cur = 0;
-        g_pc_settings.frustum_cull_x_margin = xvals[cur];
+        if (cur < 0) cur = (int)(sizeof caps / sizeof caps[0]) - 1;
+        if (cur >= (int)(sizeof caps / sizeof caps[0])) cur = 0;
+        g_pc_settings.frustum_cull_max_distance = caps[cur];
         break;
     }
     case MI_ACTOR_UPDATE_DIST: {

--- a/pc/src/pc_overlay.c
+++ b/pc/src/pc_overlay.c
@@ -103,7 +103,7 @@ static const char* menu_labels[MI_COUNT] = {
     [MI_CULL_MAX_DISTANCE]  = "Cull max dist (u)",
     [MI_ACTOR_UPDATE_DIST]  = "Actor Update Dist",
     [MI_WEATHER_PARTICLES]  = "Weather Particles",
-    [MI_SHADOW_QUALITY]     = "Shadows",
+    [MI_SHADOW_QUALITY]     = "Shadow Quality",
     [MI_REDUCE_ACRE_DRAW]   = "Acre Draw",
     [MI_BG_ANIM_THROTTLE]   = "BG Animation",
     /* MI_KB_BASE..MI_KB_BASE+KB_COUNT-1: NULL, handled via pc_keybinding_label() */
@@ -242,9 +242,9 @@ static void menu_get_value(int item, char* buf, int sz) {
         break;
     }
     case MI_SHADOW_QUALITY: {
-        static const char* snames[] = {"All", "Player Only", "Off"};
+        static const char* snames[] = {"All", "Player only", "Off", "Player + NPC"};
         int s = g_pc_settings.shadow_quality;
-        if (s < 0 || s > 2) s = 0;
+        if (s < 0 || s > 3) s = 0;
         snprintf(buf, sz, "%s", snames[s]);
         break;
     }
@@ -422,9 +422,24 @@ static void menu_adjust(int item, int dir) {
         break;
     }
     case MI_SHADOW_QUALITY: {
-        int v = g_pc_settings.shadow_quality + dir;
-        if (v < 0) v = 2; if (v > 2) v = 0;
-        g_pc_settings.shadow_quality = v;
+        /* Cycle quality high→low: All → player+NPC → player only → off */
+        static const int order[] = {0, 3, 1, 2};
+        int cur = 0;
+        int i;
+        for (i = 0; i < 4; i++) {
+            if (order[i] == g_pc_settings.shadow_quality) {
+                cur = i;
+                break;
+            }
+        }
+        cur += dir;
+        while (cur < 0) {
+            cur += 4;
+        }
+        while (cur > 3) {
+            cur -= 4;
+        }
+        g_pc_settings.shadow_quality = order[cur];
         break;
     }
     case MI_REDUCE_ACRE_DRAW: g_pc_settings.reduce_acre_draw ^= 1; break;

--- a/pc/src/pc_overlay.c
+++ b/pc/src/pc_overlay.c
@@ -248,9 +248,13 @@ static void menu_get_value(int item, char* buf, int sz) {
         snprintf(buf, sz, "%s", snames[s]);
         break;
     }
-    case MI_REDUCE_ACRE_DRAW:
-        snprintf(buf, sz, "%s", g_pc_settings.reduce_acre_draw ? "Cross (5)" : "Full (9)");
+    case MI_REDUCE_ACRE_DRAW: {
+        static const char* arnames[] = {"Full", "Cross (5)", "Current"};
+        int ar = g_pc_settings.reduce_acre_draw;
+        if (ar < 0 || ar > 2) ar = 0;
+        snprintf(buf, sz, "%s", arnames[ar]);
         break;
+    }
     case MI_BG_ANIM_THROTTLE: {
         static const char* bnames[] = {"", "Full", "Half", "", "Quarter"};
         int t = g_pc_settings.bg_anim_throttle;
@@ -442,7 +446,13 @@ static void menu_adjust(int item, int dir) {
         g_pc_settings.shadow_quality = order[cur];
         break;
     }
-    case MI_REDUCE_ACRE_DRAW: g_pc_settings.reduce_acre_draw ^= 1; break;
+    case MI_REDUCE_ACRE_DRAW: {
+        int v = g_pc_settings.reduce_acre_draw + dir;
+        if (v < 0) v = 2;
+        if (v > 2) v = 0;
+        g_pc_settings.reduce_acre_draw = v;
+        break;
+    }
     case MI_BG_ANIM_THROTTLE: {
         static const int tvals[] = {1, 2, 4};
         int cur = 0;

--- a/pc/src/pc_overlay.c
+++ b/pc/src/pc_overlay.c
@@ -215,7 +215,7 @@ static void menu_get_value(int item, char* buf, int sz) {
     case MI_CULL_Z_MARGIN:   snprintf(buf, sz, "+%d", g_pc_settings.frustum_cull_z_margin); break;
     case MI_CULL_MAX_DISTANCE: {
         if (g_pc_settings.frustum_cull_max_distance == 0)
-            snprintf(buf, sz, "Off (no cap)");
+            snprintf(buf, sz, "No cap");
         else
             snprintf(buf, sz, "%d", g_pc_settings.frustum_cull_max_distance);
         break;

--- a/pc/src/pc_overlay.c
+++ b/pc/src/pc_overlay.c
@@ -68,11 +68,8 @@ enum {
     MI_FRUSTUM_CULL,
     MI_CULL_Z_MARGIN,
     MI_CULL_MAX_DISTANCE,
-    MI_ACTOR_UPDATE_DIST,
-    MI_WEATHER_PARTICLES,
     MI_SHADOW_QUALITY,
     MI_REDUCE_ACRE_DRAW,
-    MI_BG_ANIM_THROTTLE,
     MI_KB_BASE,
     MI_COUNT = MI_KB_BASE + KB_COUNT,
 };
@@ -101,11 +98,8 @@ static const char* menu_labels[MI_COUNT] = {
     [MI_FRUSTUM_CULL]       = "Distance cull",
     [MI_CULL_Z_MARGIN]      = "Cull +range (units)",
     [MI_CULL_MAX_DISTANCE]  = "Cull max dist (u)",
-    [MI_ACTOR_UPDATE_DIST]  = "Actor Update Dist",
-    [MI_WEATHER_PARTICLES]  = "Weather Particles",
     [MI_SHADOW_QUALITY]     = "Shadow Quality",
     [MI_REDUCE_ACRE_DRAW]   = "Acre Draw",
-    [MI_BG_ANIM_THROTTLE]   = "BG Animation",
     /* MI_KB_BASE..MI_KB_BASE+KB_COUNT-1: NULL, handled via pc_keybinding_label() */
 };
 
@@ -144,11 +138,8 @@ static const int menu_item_tab[MI_COUNT] = {
     [MI_FRUSTUM_CULL]       = TAB_PERF,
     [MI_CULL_Z_MARGIN]      = TAB_PERF,
     [MI_CULL_MAX_DISTANCE]  = TAB_PERF,
-    [MI_ACTOR_UPDATE_DIST]  = TAB_PERF,
-    [MI_WEATHER_PARTICLES]  = TAB_PERF,
     [MI_SHADOW_QUALITY]     = TAB_PERF,
     [MI_REDUCE_ACRE_DRAW]   = TAB_PERF,
-    [MI_BG_ANIM_THROTTLE]   = TAB_PERF,
     /* MI_KB_BASE..MI_KB_BASE+KB_COUNT-1: handled by item_tab() helper below */
 };
 
@@ -229,18 +220,6 @@ static void menu_get_value(int item, char* buf, int sz) {
             snprintf(buf, sz, "%d", g_pc_settings.frustum_cull_max_distance);
         break;
     }
-    case MI_ACTOR_UPDATE_DIST: {
-        if (g_pc_settings.actor_update_dist == 0) snprintf(buf, sz, "Off");
-        else snprintf(buf, sz, "%d", g_pc_settings.actor_update_dist);
-        break;
-    }
-    case MI_WEATHER_PARTICLES: {
-        static const char* wnames[] = {"Full", "Reduced", "Off"};
-        int w = g_pc_settings.weather_particles;
-        if (w < 0 || w > 2) w = 0;
-        snprintf(buf, sz, "%s", wnames[w]);
-        break;
-    }
     case MI_SHADOW_QUALITY: {
         static const char* snames[] = {"All", "Player only", "Off", "Player + NPC"};
         int s = g_pc_settings.shadow_quality;
@@ -253,13 +232,6 @@ static void menu_get_value(int item, char* buf, int sz) {
         int ar = g_pc_settings.reduce_acre_draw;
         if (ar < 0 || ar > 2) ar = 0;
         snprintf(buf, sz, "%s", arnames[ar]);
-        break;
-    }
-    case MI_BG_ANIM_THROTTLE: {
-        static const char* bnames[] = {"", "Full", "Half", "", "Quarter"};
-        int t = g_pc_settings.bg_anim_throttle;
-        if (t == 1 || t == 2 || t == 4) snprintf(buf, sz, "%s", bnames[t]);
-        else snprintf(buf, sz, "%d", t);
         break;
     }
     default:
@@ -410,21 +382,6 @@ static void menu_adjust(int item, int dir) {
         g_pc_settings.frustum_cull_max_distance = caps[cur];
         break;
     }
-    case MI_ACTOR_UPDATE_DIST: {
-        static const int dvals[] = {0, 320, 480, 640};
-        int cur = 0;
-        for (int i = 0; i < 4; i++) if (dvals[i] == g_pc_settings.actor_update_dist) { cur = i; break; }
-        cur += dir;
-        if (cur < 0) cur = 3; if (cur > 3) cur = 0;
-        g_pc_settings.actor_update_dist = dvals[cur];
-        break;
-    }
-    case MI_WEATHER_PARTICLES: {
-        int v = g_pc_settings.weather_particles + dir;
-        if (v < 0) v = 2; if (v > 2) v = 0;
-        g_pc_settings.weather_particles = v;
-        break;
-    }
     case MI_SHADOW_QUALITY: {
         /* Cycle quality high→low: All → player+NPC → player only → off */
         static const int order[] = {0, 3, 1, 2};
@@ -451,15 +408,6 @@ static void menu_adjust(int item, int dir) {
         if (v < 0) v = 2;
         if (v > 2) v = 0;
         g_pc_settings.reduce_acre_draw = v;
-        break;
-    }
-    case MI_BG_ANIM_THROTTLE: {
-        static const int tvals[] = {1, 2, 4};
-        int cur = 0;
-        for (int i = 0; i < 3; i++) if (tvals[i] == g_pc_settings.bg_anim_throttle) { cur = i; break; }
-        cur += dir;
-        if (cur < 0) cur = 2; if (cur > 2) cur = 0;
-        g_pc_settings.bg_anim_throttle = tvals[cur];
         break;
     }
     default:
@@ -891,21 +839,24 @@ static void draw_menu(float cw, float ch, float pad) {
     ov_string("SETTINGS", title_x, ty, cw, ch, 1, 1, 1, 1);
     ty += row_h;
 
-    /* Tab bar — draw all tabs, highlight active one */
+    /* Tab bar — justified: distribute remaining width as equal gaps between tabs */
     {
-        int tab_col_w = cols / TAB_COUNT;
+        int total_lbl = 0;
+        for (int t = 0; t < TAB_COUNT; t++)
+            total_lbl += (int)strlen(tab_labels[t]);
+        float gap_w = (cols - total_lbl) * cw / (float)(TAB_COUNT - 1);
+        float tab_x = tx;
         for (int t = 0; t < TAB_COUNT; t++) {
-            float tab_x = tx + t * tab_col_w * cw;
             const char* lbl = tab_labels[t];
             int lbl_len = (int)strlen(lbl);
-            float lbl_x = tab_x + ((tab_col_w - lbl_len) / 2) * cw;
             if (t == s_active_tab) {
-                ov_string(lbl, lbl_x, ty, cw, ch, 1, 1, 0.3f, 1);
-                ov_quad(tab_x, ty + ch, tab_col_w * cw - pad, 2.0f,
+                ov_string(lbl, tab_x, ty, cw, ch, 1, 1, 0.3f, 1);
+                ov_quad(tab_x, ty + ch, lbl_len * cw, 2.0f,
                         BG_U, BG_V, BG_U, BG_V, 1, 1, 0.3f, 1);
             } else {
-                ov_string(lbl, lbl_x, ty, cw, ch, 0.5f, 0.5f, 0.5f, 1);
+                ov_string(lbl, tab_x, ty, cw, ch, 0.5f, 0.5f, 0.5f, 1);
             }
+            tab_x += lbl_len * cw + gap_w;
         }
         ty += row_h + pad;
     }

--- a/pc/src/pc_overlay.c
+++ b/pc/src/pc_overlay.c
@@ -64,6 +64,15 @@ enum {
     MI_LEFT_DEADZONE,
     MI_RIGHT_DEADZONE,
     MI_CTRL_RESET,
+    /* Perf tab */
+    MI_FRUSTUM_CULL,
+    MI_CULL_Z_MARGIN,
+    MI_CULL_X_MARGIN,
+    MI_ACTOR_UPDATE_DIST,
+    MI_WEATHER_PARTICLES,
+    MI_SHADOW_QUALITY,
+    MI_REDUCE_ACRE_DRAW,
+    MI_BG_ANIM_THROTTLE,
     MI_KB_BASE,
     MI_COUNT = MI_KB_BASE + KB_COUNT,
 };
@@ -89,6 +98,14 @@ static const char* menu_labels[MI_COUNT] = {
     [MI_LEFT_DEADZONE]   = "L-Stick Deadzone",
     [MI_RIGHT_DEADZONE]  = "R-Stick Deadzone",
     [MI_CTRL_RESET]      = "Reset Defaults",
+    [MI_FRUSTUM_CULL]       = "Frustum Cull",
+    [MI_CULL_Z_MARGIN]      = "Cull Z Margin",
+    [MI_CULL_X_MARGIN]      = "Cull X Margin",
+    [MI_ACTOR_UPDATE_DIST]  = "Actor Update Dist",
+    [MI_WEATHER_PARTICLES]  = "Weather Particles",
+    [MI_SHADOW_QUALITY]     = "Shadows",
+    [MI_REDUCE_ACRE_DRAW]   = "Acre Draw",
+    [MI_BG_ANIM_THROTTLE]   = "BG Animation",
     /* MI_KB_BASE..MI_KB_BASE+KB_COUNT-1: NULL, handled via pc_keybinding_label() */
 };
 
@@ -99,8 +116,8 @@ static const char* get_item_label(int i) {
 }
 
 /* ---- Menu tabs ---- */
-enum { TAB_VIDEO, TAB_AUDIO, TAB_CONTROLS, TAB_DEBUG, TAB_COUNT };
-static const char* tab_labels[TAB_COUNT] = { "VIDEO", "AUDIO", "CTRL", "DEBUG" };
+enum { TAB_VIDEO, TAB_AUDIO, TAB_CONTROLS, TAB_DEBUG, TAB_PERF, TAB_COUNT };
+static const char* tab_labels[TAB_COUNT] = { "VIDEO", "AUDIO", "CTRL", "DEBUG", "PERF" };
 static int s_active_tab = 0;
 
 /* Which tab each menu item belongs to (indexed by MI_*) */
@@ -124,6 +141,14 @@ static const int menu_item_tab[MI_COUNT] = {
     [MI_LEFT_DEADZONE]   = TAB_CONTROLS,
     [MI_RIGHT_DEADZONE]  = TAB_CONTROLS,
     [MI_CTRL_RESET]      = TAB_CONTROLS,
+    [MI_FRUSTUM_CULL]       = TAB_PERF,
+    [MI_CULL_Z_MARGIN]      = TAB_PERF,
+    [MI_CULL_X_MARGIN]      = TAB_PERF,
+    [MI_ACTOR_UPDATE_DIST]  = TAB_PERF,
+    [MI_WEATHER_PARTICLES]  = TAB_PERF,
+    [MI_SHADOW_QUALITY]     = TAB_PERF,
+    [MI_REDUCE_ACRE_DRAW]   = TAB_PERF,
+    [MI_BG_ANIM_THROTTLE]   = TAB_PERF,
     /* MI_KB_BASE..MI_KB_BASE+KB_COUNT-1: handled by item_tab() helper below */
 };
 
@@ -195,6 +220,45 @@ static void menu_get_value(int item, char* buf, int sz) {
     case MI_LEFT_DEADZONE:   snprintf(buf, sz, "%d%%", g_pc_settings.left_deadzone); break;
     case MI_RIGHT_DEADZONE:  snprintf(buf, sz, "%d%%", g_pc_settings.right_deadzone); break;
     case MI_CTRL_RESET:      snprintf(buf, sz, "Press >"); break;
+    case MI_FRUSTUM_CULL:    snprintf(buf, sz, "%s", g_pc_settings.frustum_cull ? "ON" : "OFF"); break;
+    case MI_CULL_Z_MARGIN:   snprintf(buf, sz, "%d", g_pc_settings.frustum_cull_z_margin); break;
+    case MI_CULL_X_MARGIN: {
+        static const char* xnames[] = {"Tight", "Normal", "Loose", "V.Loose"};
+        static const int   xvals[]  = {10, 15, 20, 30};
+        int cur = 1;
+        for (int i = 0; i < 4; i++) if (xvals[i] == g_pc_settings.frustum_cull_x_margin) { cur = i; break; }
+        snprintf(buf, sz, "%s", xnames[cur]);
+        break;
+    }
+    case MI_ACTOR_UPDATE_DIST: {
+        if (g_pc_settings.actor_update_dist == 0) snprintf(buf, sz, "Off");
+        else snprintf(buf, sz, "%d", g_pc_settings.actor_update_dist);
+        break;
+    }
+    case MI_WEATHER_PARTICLES: {
+        static const char* wnames[] = {"Full", "Reduced", "Off"};
+        int w = g_pc_settings.weather_particles;
+        if (w < 0 || w > 2) w = 0;
+        snprintf(buf, sz, "%s", wnames[w]);
+        break;
+    }
+    case MI_SHADOW_QUALITY: {
+        static const char* snames[] = {"All", "Player Only", "Off"};
+        int s = g_pc_settings.shadow_quality;
+        if (s < 0 || s > 2) s = 0;
+        snprintf(buf, sz, "%s", snames[s]);
+        break;
+    }
+    case MI_REDUCE_ACRE_DRAW:
+        snprintf(buf, sz, "%s", g_pc_settings.reduce_acre_draw ? "Cross (5)" : "Full (9)");
+        break;
+    case MI_BG_ANIM_THROTTLE: {
+        static const char* bnames[] = {"", "Full", "Half", "", "Quarter"};
+        int t = g_pc_settings.bg_anim_throttle;
+        if (t == 1 || t == 2 || t == 4) snprintf(buf, sz, "%s", bnames[t]);
+        else snprintf(buf, sz, "%d", t);
+        break;
+    }
     default:
         if (item >= MI_KB_BASE && item < MI_KB_BASE + KB_COUNT) {
             int kb_idx = item - MI_KB_BASE;
@@ -318,6 +382,53 @@ static void menu_adjust(int item, int dir) {
         break;
     }
     case MI_CTRL_RESET:      pc_keybindings_reset(); break;
+    case MI_FRUSTUM_CULL:    g_pc_settings.frustum_cull ^= 1; break;
+    case MI_CULL_Z_MARGIN: {
+        int v = g_pc_settings.frustum_cull_z_margin + dir * 10;
+        if (v < 0) v = 0; if (v > 200) v = 200;
+        g_pc_settings.frustum_cull_z_margin = v;
+        break;
+    }
+    case MI_CULL_X_MARGIN: {
+        static const int xvals[] = {10, 15, 20, 30};
+        int cur = 1;
+        for (int i = 0; i < 4; i++) if (xvals[i] == g_pc_settings.frustum_cull_x_margin) { cur = i; break; }
+        cur += dir;
+        if (cur < 0) cur = 3; if (cur > 3) cur = 0;
+        g_pc_settings.frustum_cull_x_margin = xvals[cur];
+        break;
+    }
+    case MI_ACTOR_UPDATE_DIST: {
+        static const int dvals[] = {0, 320, 480, 640};
+        int cur = 0;
+        for (int i = 0; i < 4; i++) if (dvals[i] == g_pc_settings.actor_update_dist) { cur = i; break; }
+        cur += dir;
+        if (cur < 0) cur = 3; if (cur > 3) cur = 0;
+        g_pc_settings.actor_update_dist = dvals[cur];
+        break;
+    }
+    case MI_WEATHER_PARTICLES: {
+        int v = g_pc_settings.weather_particles + dir;
+        if (v < 0) v = 2; if (v > 2) v = 0;
+        g_pc_settings.weather_particles = v;
+        break;
+    }
+    case MI_SHADOW_QUALITY: {
+        int v = g_pc_settings.shadow_quality + dir;
+        if (v < 0) v = 2; if (v > 2) v = 0;
+        g_pc_settings.shadow_quality = v;
+        break;
+    }
+    case MI_REDUCE_ACRE_DRAW: g_pc_settings.reduce_acre_draw ^= 1; break;
+    case MI_BG_ANIM_THROTTLE: {
+        static const int tvals[] = {1, 2, 4};
+        int cur = 0;
+        for (int i = 0; i < 3; i++) if (tvals[i] == g_pc_settings.bg_anim_throttle) { cur = i; break; }
+        cur += dir;
+        if (cur < 0) cur = 2; if (cur > 2) cur = 0;
+        g_pc_settings.bg_anim_throttle = tvals[cur];
+        break;
+    }
     default:
         if (item >= MI_KB_BASE && item < MI_KB_BASE + KB_COUNT && dir == 1) {
             ctrl_capture_idx = item - MI_KB_BASE;

--- a/pc/src/pc_overlay.c
+++ b/pc/src/pc_overlay.c
@@ -186,9 +186,9 @@ static void menu_get_value(int item, char* buf, int sz) {
         break;
     case MI_ZOOM_ENABLED:  snprintf(buf, sz, "%s", g_pc_settings.zoom_enabled ? "ON" : "OFF"); break;
     case MI_FPS_TARGET: {
-        static const char* names[] = {"60 FPS", "50 FPS", "40 FPS", "30 FPS", "20 FPS", "Unlimited", "Auto", "Dynamic"};
+        static const char* names[] = {"60 FPS", "50 FPS", "40 FPS", "30 FPS", "20 FPS", "Unlimited", "Dynamic"};
         int t = g_pc_settings.fps_target;
-        if (t < 0 || t > 7) t = 0;
+        if (t < 0 || t > 6) t = 0;
         snprintf(buf, sz, "%s", names[t]);
         break;
     }
@@ -303,9 +303,9 @@ static void menu_adjust(int item, int dir) {
     case MI_FPS_TARGET: {
         /* Right = faster (lower index), Left = slower (higher index) */
         int v = g_pc_settings.fps_target - dir;
-        if (v < 0) v = 7; if (v > 7) v = 0;
+        if (v < 0) v = 6; if (v > 6) v = 0;
         g_pc_settings.fps_target = v;
-        static const int fps_hz[8] = {60, 50, 40, 30, 20, 0, 60, 60};
+        static const int fps_hz[7] = {60, 50, 40, 30, 20, 0, 60};
         g_pc_fps_target = fps_hz[v];
         if (v == 5) g_pc_no_framelimit = 1;
         else        g_pc_no_framelimit = 0;
@@ -786,7 +786,7 @@ static void menu_process_input(void) {
 /* ---- Draw: FPS counter (top-right corner) ---- */
 static void draw_fps(float cw, float ch, float pad) {
     char line1[32], line2[32];
-    if (g_pc_fps_target > 0 && g_pc_settings.fps_target != 7)
+    if (g_pc_fps_target > 0 && g_pc_settings.fps_target != 6)
         snprintf(line1, sizeof(line1), "%.1f/%d FPS", ov_fps, g_pc_fps_target);
     else
         snprintf(line1, sizeof(line1), "%.1f FPS", ov_fps);

--- a/pc/src/pc_settings.c
+++ b/pc/src/pc_settings.c
@@ -2,6 +2,16 @@
 #include "pc_settings.h"
 #include "pc_platform.h"
 
+float pc_settings_cull_limit_xz(float cull_distance, float cull_radius) {
+    float t = cull_distance + cull_radius + (float)g_pc_settings.frustum_cull_z_margin;
+    int cap = g_pc_settings.frustum_cull_max_distance;
+
+    if (cap > 0 && t > (float)cap) {
+        t = (float)cap;
+    }
+    return t;
+}
+
 PCSettings g_pc_settings = {
     .window_width  = PC_SCREEN_WIDTH,
     .window_height = PC_SCREEN_HEIGHT,
@@ -25,9 +35,9 @@ PCSettings g_pc_settings = {
     .left_deadzone  = 0,
     .right_deadzone = 0,
     .swap_ab_xy     = 0,
-    .frustum_cull           = 0,
-    .frustum_cull_z_margin  = 50,
-    .frustum_cull_x_margin  = 15,
+    .frustum_cull              = 0,
+    .frustum_cull_z_margin     = 50,
+    .frustum_cull_max_distance = 0,
     .actor_update_dist      = 0,
     .weather_particles      = 0,
     .shadow_quality         = 0,
@@ -93,20 +103,21 @@ static const char* DEFAULT_SETTINGS =
     "\n"
     "# Left/right stick deadzone in percent (0-50, increments of 5)\n"
     "left_deadzone = 0\n"
-    "right_deadzone = 0\n";
+    "right_deadzone = 0\n"
     "\n"
     "# Swap A↔B and X↔Y: 0 = off, 1 = on\n"
     "swap_ab_xy = 0\n"
     "\n"
     "[LowSpec]\n"
-    "# Frustum culling: 0=off (original behavior), 1=on\n"
+    "# Distance cull (props/actors vs player XZ): 0=off, 1=on (not GPU frustum)\n"
     "frustum_cull = 0\n"
     "\n"
-    "# Frustum cull Z margin: extra world units of padding on depth (0-200)\n"
+    "# Extra draw range in world units (0-200). Higher = draw farther = less culling.\n"
     "frustum_cull_z_margin = 50\n"
     "\n"
-    "# Frustum cull X margin as 10ths: 10=tight, 15=normal, 20=loose, 30=very loose\n"
-    "frustum_cull_x_margin = 15\n"
+    "# Hard max XZ draw distance (0 = no cap, use per-object range + margin only).\n"
+    "# Set e.g. 500-800 to see distant trees/props disappear (lower = more aggressive).\n"
+    "frustum_cull_max_distance = 0\n"
     "\n"
     "# Actor update distance: 0=off, or max XZ units for non-NPC logic (320/480/640)\n"
     "actor_update_dist = 0\n"
@@ -190,8 +201,11 @@ static void apply_setting(const char* key, const char* value) {
         if (val == 0 || val == 1) g_pc_settings.frustum_cull = val;
     } else if (strcmp(key, "frustum_cull_z_margin") == 0) {
         if (val >= 0 && val <= 200) g_pc_settings.frustum_cull_z_margin = val;
+    } else if (strcmp(key, "frustum_cull_max_distance") == 0) {
+        if (val >= 0 && val <= 2500) g_pc_settings.frustum_cull_max_distance = val;
     } else if (strcmp(key, "frustum_cull_x_margin") == 0) {
-        if (val >= 5 && val <= 50) g_pc_settings.frustum_cull_x_margin = val;
+        /* Legacy ini key (was unused in-game). Ignored. */
+        (void)val;
     } else if (strcmp(key, "actor_update_dist") == 0) {
         if (val >= 0) g_pc_settings.actor_update_dist = val;
     } else if (strcmp(key, "weather_particles") == 0) {
@@ -272,14 +286,14 @@ void pc_settings_save(void) {
     fprintf(f, "right_deadzone = %d\n", g_pc_settings.right_deadzone);
     fprintf(f, "\n");
     fprintf(f, "[LowSpec]\n");
-    fprintf(f, "# Frustum culling: 0=off (original behavior), 1=on\n");
+    fprintf(f, "# Distance cull vs player XZ: 0=off, 1=on\n");
     fprintf(f, "frustum_cull = %d\n", g_pc_settings.frustum_cull);
     fprintf(f, "\n");
-    fprintf(f, "# Frustum cull Z margin: extra world units of padding on depth (0-200)\n");
+    fprintf(f, "# Extra draw range (world units, 0-200). Higher = less culling.\n");
     fprintf(f, "frustum_cull_z_margin = %d\n", g_pc_settings.frustum_cull_z_margin);
     fprintf(f, "\n");
-    fprintf(f, "# Frustum cull X margin as 10ths: 10=tight, 15=normal, 20=loose, 30=very loose\n");
-    fprintf(f, "frustum_cull_x_margin = %d\n", g_pc_settings.frustum_cull_x_margin);
+    fprintf(f, "# Max XZ draw distance (0=no cap). Lower = more culling (try 500-900 to verify).\n");
+    fprintf(f, "frustum_cull_max_distance = %d\n", g_pc_settings.frustum_cull_max_distance);
     fprintf(f, "\n");
     fprintf(f, "# Actor update distance: 0=off, or max XZ units for non-NPC logic\n");
     fprintf(f, "actor_update_dist = %d\n", g_pc_settings.actor_update_dist);

--- a/pc/src/pc_settings.c
+++ b/pc/src/pc_settings.c
@@ -38,11 +38,8 @@ PCSettings g_pc_settings = {
     .frustum_cull              = 0,
     .frustum_cull_z_margin     = 50,
     .frustum_cull_max_distance = 0,
-    .actor_update_dist      = 0,
-    .weather_particles      = 0,
     .shadow_quality         = 0,
     .reduce_acre_draw       = 0,
-    .bg_anim_throttle       = 1,
 };
 
 static const char* SETTINGS_FILE = "settings.ini";
@@ -119,20 +116,11 @@ static const char* DEFAULT_SETTINGS =
     "# Set e.g. 500-800 to see distant trees/props disappear (lower = more aggressive).\n"
     "frustum_cull_max_distance = 0\n"
     "\n"
-    "# Actor update distance: 0=off, or max XZ units for non-NPC logic (320/480/640)\n"
-    "actor_update_dist = 0\n"
-    "\n"
-    "# Weather particles: 0=full, 1=reduced (half spawn), 2=off\n"
-    "weather_particles = 0\n"
-    "\n"
     "# Shadow quality: 0=all, 1=player only, 2=off (actors + trees/sign decals), 3=player+NPC\n"
     "shadow_quality = 0\n"
     "\n"
     "# Acre background draw: 0=full (adjacent), 1=cross (orthogonal only), 2=current acre only\n"
-    "reduce_acre_draw = 0\n"
-    "\n"
-    "# BG animation throttle: 1=every frame, 2=half-rate, 4=quarter-rate\n"
-    "bg_anim_throttle = 1\n";
+    "reduce_acre_draw = 0\n";
 
 static const char* skip_ws(const char* s) {
     while (*s == ' ' || *s == '\t') s++;
@@ -206,16 +194,10 @@ static void apply_setting(const char* key, const char* value) {
     } else if (strcmp(key, "frustum_cull_x_margin") == 0) {
         /* Legacy ini key (was unused in-game). Ignored. */
         (void)val;
-    } else if (strcmp(key, "actor_update_dist") == 0) {
-        if (val >= 0) g_pc_settings.actor_update_dist = val;
-    } else if (strcmp(key, "weather_particles") == 0) {
-        if (val >= 0 && val <= 2) g_pc_settings.weather_particles = val;
     } else if (strcmp(key, "shadow_quality") == 0) {
         if (val >= 0 && val <= 3) g_pc_settings.shadow_quality = val;
     } else if (strcmp(key, "reduce_acre_draw") == 0) {
         if (val >= 0 && val <= 2) g_pc_settings.reduce_acre_draw = val;
-    } else if (strcmp(key, "bg_anim_throttle") == 0) {
-        if (val == 1 || val == 2 || val == 4) g_pc_settings.bg_anim_throttle = val;
     }
 }
 
@@ -295,20 +277,11 @@ void pc_settings_save(void) {
     fprintf(f, "# Max XZ draw distance (0=no cap). Lower = more culling (try 500-900 to verify).\n");
     fprintf(f, "frustum_cull_max_distance = %d\n", g_pc_settings.frustum_cull_max_distance);
     fprintf(f, "\n");
-    fprintf(f, "# Actor update distance: 0=off, or max XZ units for non-NPC logic\n");
-    fprintf(f, "actor_update_dist = %d\n", g_pc_settings.actor_update_dist);
-    fprintf(f, "\n");
-    fprintf(f, "# Weather particles: 0=full, 1=reduced, 2=off\n");
-    fprintf(f, "weather_particles = %d\n", g_pc_settings.weather_particles);
-    fprintf(f, "\n");
     fprintf(f, "# Shadow quality: 0=all, 1=player only, 2=off, 3=player+NPC\n");
     fprintf(f, "shadow_quality = %d\n", g_pc_settings.shadow_quality);
     fprintf(f, "\n");
     fprintf(f, "# Acre background draw: 0=full (adjacent), 1=cross (orthogonal only), 2=current acre only\n");
     fprintf(f, "reduce_acre_draw = %d\n", g_pc_settings.reduce_acre_draw);
-    fprintf(f, "\n");
-    fprintf(f, "# BG animation throttle: 1=every frame, 2=half-rate, 4=quarter-rate\n");
-    fprintf(f, "bg_anim_throttle = %d\n", g_pc_settings.bg_anim_throttle);
     fclose(f);
     printf("[Settings] Saved %s\n", SETTINGS_FILE);
 }

--- a/pc/src/pc_settings.c
+++ b/pc/src/pc_settings.c
@@ -64,7 +64,7 @@ static const char* DEFAULT_SETTINGS =
     "preload_textures = 0\n"
     "\n"
     "[Performance]\n"
-    "# FPS target: 0=60fps, 1=50fps, 2=40fps, 3=30fps, 4=20fps, 5=unlimited, 6=auto, 7=dynamic\n"
+    "# FPS target: 0=60fps, 1=50fps, 2=40fps, 3=30fps, 4=20fps, 5=unlimited, 6=dynamic\n"
     "fps_target = 0\n"
     "\n"
     "# Render scale %%: 100=native, 75, 50, 25 (lower = faster on limited hardware)\n"
@@ -157,7 +157,7 @@ static void apply_setting(const char* key, const char* value) {
             g_pc_settings.fps_target = 3; /* 30fps */
         g_pc_settings.frameskip = val;
     } else if (strcmp(key, "fps_target") == 0) {
-        if (val >= 0 && val <= 7) g_pc_settings.fps_target = val;
+        if (val >= 0 && val <= 6) g_pc_settings.fps_target = val;
     } else if (strcmp(key, "render_scale") == 0) {
         if (val == 25 || val == 50 || val == 75 || val == 100)
             g_pc_settings.render_scale = val;
@@ -236,7 +236,7 @@ void pc_settings_save(void) {
     fprintf(f, "preload_textures = %d\n", g_pc_settings.preload_textures);
     fprintf(f, "\n");
     fprintf(f, "[Performance]\n");
-    fprintf(f, "# FPS target: 0=60fps, 1=50fps, 2=40fps, 3=30fps, 4=20fps, 5=unlimited, 6=auto\n");
+    fprintf(f, "# FPS target: 0=60fps, 1=50fps, 2=40fps, 3=30fps, 4=20fps, 5=unlimited, 6=dynamic\n");
     fprintf(f, "fps_target = %d\n", g_pc_settings.fps_target);
     fprintf(f, "\n");
     fprintf(f, "# Render scale %%: 100=native, 75, 50, 25\n");
@@ -308,7 +308,7 @@ static const int s_window_presets[5][2] = {
 };
 
 /* FPS target enum -> actual Hz */
-static const int s_fps_target_hz[8] = {60, 50, 40, 30, 20, 0, 60, 60}; /* 6=auto, 7=dynamic start at 60 */
+static const int s_fps_target_hz[7] = {60, 50, 40, 30, 20, 0, 60}; /* 6=dynamic starts at 60 */
 
 void pc_settings_apply(void) {
     if (!g_pc_window) return;
@@ -331,7 +331,7 @@ void pc_settings_apply(void) {
 
     /* Apply fps_target to the global used by the frame pacing system */
     int ti = g_pc_settings.fps_target;
-    if (ti < 0 || ti > 7) ti = 0;
+    if (ti < 0 || ti > 6) ti = 0;
     g_pc_fps_target = s_fps_target_hz[ti];
 
     pc_platform_update_window_size(); /* also updates g_pc_render_w/h */

--- a/pc/src/pc_settings.c
+++ b/pc/src/pc_settings.c
@@ -24,6 +24,15 @@ PCSettings g_pc_settings = {
     .dpad_as_stick  = 0,
     .left_deadzone  = 0,
     .right_deadzone = 0,
+    .swap_ab_xy     = 0,
+    .frustum_cull           = 0,
+    .frustum_cull_z_margin  = 50,
+    .frustum_cull_x_margin  = 15,
+    .actor_update_dist      = 0,
+    .weather_particles      = 0,
+    .shadow_quality         = 0,
+    .reduce_acre_draw       = 0,
+    .bg_anim_throttle       = 1,
 };
 
 static const char* SETTINGS_FILE = "settings.ini";
@@ -85,6 +94,34 @@ static const char* DEFAULT_SETTINGS =
     "# Left/right stick deadzone in percent (0-50, increments of 5)\n"
     "left_deadzone = 0\n"
     "right_deadzone = 0\n";
+    "\n"
+    "# Swap A↔B and X↔Y: 0 = off, 1 = on\n"
+    "swap_ab_xy = 0\n"
+    "\n"
+    "[LowSpec]\n"
+    "# Frustum culling: 0=off (original behavior), 1=on\n"
+    "frustum_cull = 0\n"
+    "\n"
+    "# Frustum cull Z margin: extra world units of padding on depth (0-200)\n"
+    "frustum_cull_z_margin = 50\n"
+    "\n"
+    "# Frustum cull X margin as 10ths: 10=tight, 15=normal, 20=loose, 30=very loose\n"
+    "frustum_cull_x_margin = 15\n"
+    "\n"
+    "# Actor update distance: 0=off, or max XZ units for non-NPC logic (320/480/640)\n"
+    "actor_update_dist = 0\n"
+    "\n"
+    "# Weather particles: 0=full, 1=reduced (half spawn), 2=off\n"
+    "weather_particles = 0\n"
+    "\n"
+    "# Shadow quality: 0=all actors, 1=player only, 2=off\n"
+    "shadow_quality = 0\n"
+    "\n"
+    "# Acre background draw: 0=full 3x3 (9 acres), 1=cross (5 acres, skip diagonals)\n"
+    "reduce_acre_draw = 0\n"
+    "\n"
+    "# BG animation throttle: 1=every frame, 2=half-rate, 4=quarter-rate\n"
+    "bg_anim_throttle = 1\n";
 
 static const char* skip_ws(const char* s) {
     while (*s == ' ' || *s == '\t') s++;
@@ -149,6 +186,22 @@ static void apply_setting(const char* key, const char* value) {
         if (val >= 0 && val <= 50) g_pc_settings.left_deadzone = val;
     } else if (strcmp(key, "right_deadzone") == 0) {
         if (val >= 0 && val <= 50) g_pc_settings.right_deadzone = val;
+    } else if (strcmp(key, "frustum_cull") == 0) {
+        if (val == 0 || val == 1) g_pc_settings.frustum_cull = val;
+    } else if (strcmp(key, "frustum_cull_z_margin") == 0) {
+        if (val >= 0 && val <= 200) g_pc_settings.frustum_cull_z_margin = val;
+    } else if (strcmp(key, "frustum_cull_x_margin") == 0) {
+        if (val >= 5 && val <= 50) g_pc_settings.frustum_cull_x_margin = val;
+    } else if (strcmp(key, "actor_update_dist") == 0) {
+        if (val >= 0) g_pc_settings.actor_update_dist = val;
+    } else if (strcmp(key, "weather_particles") == 0) {
+        if (val >= 0 && val <= 2) g_pc_settings.weather_particles = val;
+    } else if (strcmp(key, "shadow_quality") == 0) {
+        if (val >= 0 && val <= 2) g_pc_settings.shadow_quality = val;
+    } else if (strcmp(key, "reduce_acre_draw") == 0) {
+        if (val == 0 || val == 1) g_pc_settings.reduce_acre_draw = val;
+    } else if (strcmp(key, "bg_anim_throttle") == 0) {
+        if (val == 1 || val == 2 || val == 4) g_pc_settings.bg_anim_throttle = val;
     }
 }
 
@@ -217,6 +270,31 @@ void pc_settings_save(void) {
     fprintf(f, "# Left/right stick deadzone in percent (0-50)\n");
     fprintf(f, "left_deadzone = %d\n", g_pc_settings.left_deadzone);
     fprintf(f, "right_deadzone = %d\n", g_pc_settings.right_deadzone);
+    fprintf(f, "\n");
+    fprintf(f, "[LowSpec]\n");
+    fprintf(f, "# Frustum culling: 0=off (original behavior), 1=on\n");
+    fprintf(f, "frustum_cull = %d\n", g_pc_settings.frustum_cull);
+    fprintf(f, "\n");
+    fprintf(f, "# Frustum cull Z margin: extra world units of padding on depth (0-200)\n");
+    fprintf(f, "frustum_cull_z_margin = %d\n", g_pc_settings.frustum_cull_z_margin);
+    fprintf(f, "\n");
+    fprintf(f, "# Frustum cull X margin as 10ths: 10=tight, 15=normal, 20=loose, 30=very loose\n");
+    fprintf(f, "frustum_cull_x_margin = %d\n", g_pc_settings.frustum_cull_x_margin);
+    fprintf(f, "\n");
+    fprintf(f, "# Actor update distance: 0=off, or max XZ units for non-NPC logic\n");
+    fprintf(f, "actor_update_dist = %d\n", g_pc_settings.actor_update_dist);
+    fprintf(f, "\n");
+    fprintf(f, "# Weather particles: 0=full, 1=reduced, 2=off\n");
+    fprintf(f, "weather_particles = %d\n", g_pc_settings.weather_particles);
+    fprintf(f, "\n");
+    fprintf(f, "# Shadow quality: 0=all actors, 1=player only, 2=off\n");
+    fprintf(f, "shadow_quality = %d\n", g_pc_settings.shadow_quality);
+    fprintf(f, "\n");
+    fprintf(f, "# Acre background draw: 0=full 3x3, 1=cross (5 acres)\n");
+    fprintf(f, "reduce_acre_draw = %d\n", g_pc_settings.reduce_acre_draw);
+    fprintf(f, "\n");
+    fprintf(f, "# BG animation throttle: 1=every frame, 2=half-rate, 4=quarter-rate\n");
+    fprintf(f, "bg_anim_throttle = %d\n", g_pc_settings.bg_anim_throttle);
     fclose(f);
     printf("[Settings] Saved %s\n", SETTINGS_FILE);
 }

--- a/pc/src/pc_settings.c
+++ b/pc/src/pc_settings.c
@@ -125,7 +125,7 @@ static const char* DEFAULT_SETTINGS =
     "# Weather particles: 0=full, 1=reduced (half spawn), 2=off\n"
     "weather_particles = 0\n"
     "\n"
-    "# Shadow quality: 0=all actors, 1=player only, 2=off\n"
+    "# Shadow quality: 0=all, 1=player only, 2=off (actors + trees/sign decals), 3=player+NPC\n"
     "shadow_quality = 0\n"
     "\n"
     "# Acre background draw: 0=full 3x3 (9 acres), 1=cross (5 acres, skip diagonals)\n"
@@ -211,7 +211,7 @@ static void apply_setting(const char* key, const char* value) {
     } else if (strcmp(key, "weather_particles") == 0) {
         if (val >= 0 && val <= 2) g_pc_settings.weather_particles = val;
     } else if (strcmp(key, "shadow_quality") == 0) {
-        if (val >= 0 && val <= 2) g_pc_settings.shadow_quality = val;
+        if (val >= 0 && val <= 3) g_pc_settings.shadow_quality = val;
     } else if (strcmp(key, "reduce_acre_draw") == 0) {
         if (val == 0 || val == 1) g_pc_settings.reduce_acre_draw = val;
     } else if (strcmp(key, "bg_anim_throttle") == 0) {
@@ -301,7 +301,7 @@ void pc_settings_save(void) {
     fprintf(f, "# Weather particles: 0=full, 1=reduced, 2=off\n");
     fprintf(f, "weather_particles = %d\n", g_pc_settings.weather_particles);
     fprintf(f, "\n");
-    fprintf(f, "# Shadow quality: 0=all actors, 1=player only, 2=off\n");
+    fprintf(f, "# Shadow quality: 0=all, 1=player only, 2=off, 3=player+NPC\n");
     fprintf(f, "shadow_quality = %d\n", g_pc_settings.shadow_quality);
     fprintf(f, "\n");
     fprintf(f, "# Acre background draw: 0=full 3x3, 1=cross (5 acres)\n");

--- a/pc/src/pc_settings.c
+++ b/pc/src/pc_settings.c
@@ -128,7 +128,7 @@ static const char* DEFAULT_SETTINGS =
     "# Shadow quality: 0=all, 1=player only, 2=off (actors + trees/sign decals), 3=player+NPC\n"
     "shadow_quality = 0\n"
     "\n"
-    "# Acre background draw: 0=full 3x3 (9 acres), 1=cross (5 acres, skip diagonals)\n"
+    "# Acre background draw: 0=full (adjacent), 1=cross (orthogonal only), 2=current acre only\n"
     "reduce_acre_draw = 0\n"
     "\n"
     "# BG animation throttle: 1=every frame, 2=half-rate, 4=quarter-rate\n"
@@ -213,7 +213,7 @@ static void apply_setting(const char* key, const char* value) {
     } else if (strcmp(key, "shadow_quality") == 0) {
         if (val >= 0 && val <= 3) g_pc_settings.shadow_quality = val;
     } else if (strcmp(key, "reduce_acre_draw") == 0) {
-        if (val == 0 || val == 1) g_pc_settings.reduce_acre_draw = val;
+        if (val >= 0 && val <= 2) g_pc_settings.reduce_acre_draw = val;
     } else if (strcmp(key, "bg_anim_throttle") == 0) {
         if (val == 1 || val == 2 || val == 4) g_pc_settings.bg_anim_throttle = val;
     }
@@ -304,7 +304,7 @@ void pc_settings_save(void) {
     fprintf(f, "# Shadow quality: 0=all, 1=player only, 2=off, 3=player+NPC\n");
     fprintf(f, "shadow_quality = %d\n", g_pc_settings.shadow_quality);
     fprintf(f, "\n");
-    fprintf(f, "# Acre background draw: 0=full 3x3, 1=cross (5 acres)\n");
+    fprintf(f, "# Acre background draw: 0=full (adjacent), 1=cross (orthogonal only), 2=current acre only\n");
     fprintf(f, "reduce_acre_draw = %d\n", g_pc_settings.reduce_acre_draw);
     fprintf(f, "\n");
     fprintf(f, "# BG animation throttle: 1=every frame, 2=half-rate, 4=quarter-rate\n");

--- a/pc/src/pc_vi.c
+++ b/pc/src/pc_vi.c
@@ -38,44 +38,13 @@ void VISetNextFrameBuffer(void* fb) { (void)fb; }
 
 void VIFlush(void) {}
 
-/* --- Auto-adaptive FPS controller ---
- * Monitors render FPS vs target and drops/raises the FPS tier automatically
- * when fps_target == 5 (Auto). */
-static void pc_adaptive_fps_update(double render_fps) {
-    static int tier = 0;    /* 0=60, 1=50, 2=40, 3=30, 4=20 */
-    static int stable = 0;
-    static const int tiers[5] = {60, 50, 40, 30, 20};
-
-    if (g_pc_settings.fps_target != 6) return; /* only in Auto mode */
-
-    int target = tiers[tier];
-    if (render_fps < target * 0.85 && tier < 4) {
-        /* Struggling: drop to next lower tier immediately */
-        tier++;
-        stable = 0;
-        g_pc_fps_target = tiers[tier];
-        printf("[VI] Auto FPS: dropped to %d fps (render=%.1f)\n", g_pc_fps_target, render_fps);
-    } else if (render_fps > target * 1.10 && tier > 0) {
-        /* Headroom: promote after 2 seconds of stable performance */
-        stable++;
-        if (stable > 4) {
-            tier--;
-            stable = 0;
-            g_pc_fps_target = tiers[tier];
-            printf("[VI] Auto FPS: raised to %d fps (render=%.1f)\n", g_pc_fps_target, render_fps);
-        }
-    } else {
-        stable = 0;
-    }
-}
-
 void pc_dynamic_fps_reset(void) {
     s_dyn_ema_us = 0.0;
     s_dyn_inited = 0;
 }
 
 static void pc_dynamic_fps_update(Uint64 work_us) {
-    if (g_pc_settings.fps_target != 7) return;
+    if (g_pc_settings.fps_target != 6) return;
 
     /* EMA alpha=0.25: absorbs single-frame spikes, reacts to sustained load in ~4 frames */
     if (!s_dyn_inited) {
@@ -131,7 +100,7 @@ void VIWaitForRetrace(void) {
     Uint64 t_after_swap = SDL_GetPerformanceCounter();
 
     /* Dynamic FPS: compute optimal fps from actual work cost before the pacing wait */
-    if (g_pc_settings.fps_target == 7 && frame_start_time) {
+    if (g_pc_settings.fps_target == 6 && frame_start_time) {
         Uint64 work_us = (t_after_swap - frame_start_time) * 1000000 / perf_freq;
         pc_dynamic_fps_update(work_us);
     }
@@ -207,8 +176,6 @@ void VIWaitForRetrace(void) {
                        render_fps, speed_pct, pc_gx_draw_call_count, pc_emu64_frame_cmds,
                        pc_emu64_frame_crashes, flush_ms, texld_ms);
             }
-
-            pc_adaptive_fps_update(render_fps);
 
             fps_start = now;
             fps_count = 0;

--- a/src/bg_item/bg_item_clip.c_inc
+++ b/src/bg_item/bg_item_clip.c_inc
@@ -1,3 +1,7 @@
+#ifdef TARGET_PC
+#include "pc_settings.h"
+#endif
+
 static void bIT_copy_vtx(Vtx* dst, Vtx* src, u32 count, u8* fix_table, int fix_adjust_pos) {
     int i;
 
@@ -14,6 +18,11 @@ static void bIT_copy_vtx(Vtx* dst, Vtx* src, u32 count, u8* fix_table, int fix_a
 }
 
 static void bIT_draw_shadow(GAME* game, bIT_ShadowData_c* data, int type) {
+#ifdef TARGET_PC
+    if (g_pc_settings.shadow_quality == 2) {
+        return;
+    }
+#endif
     GRAPH* graph = game->graph;
     Kankyo* kankyo = &((GAME_PLAY*)game)->kankyo;
     Vtx* vtx = (Vtx*)GRAPH_ALLOC_TYPE(graph, Vtx, data->vtx_num);

--- a/src/bg_item/bg_item_common.c_inc
+++ b/src/bg_item/bg_item_common.c_inc
@@ -1767,6 +1767,11 @@ static void bit_cmn_single_draw_loop_type1(GRAPH* graph, Gfx** gfx_pp, bIT_draw_
 
 static void bit_cmn_single_draw_item_shadow(GRAPH* graph, bg_item_draw_part_c* draw_part,
                                             bIT_draw_pos_entry_c* draw_pos_entry, f32 shadow_pos, const rgba_t* color) {
+#ifdef TARGET_PC
+    if (g_pc_settings.shadow_quality == 2) {
+        return;
+    }
+#endif
     bg_item_draw_list_c* draw_list = draw_part->shadow_draw_list;
 
     if (draw_list != NULL) {
@@ -3020,6 +3025,11 @@ static void bg_item_common_draw_item_shadow(GRAPH* graph, Gfx** gfx_pp, bg_item_
                                             bg_item_draw_pos_c* draw_pos, f32 shadow_pos, const rgba_t* shadow_color) {
     bg_item_draw_list_c* draw_list = draw_part->shadow_draw_list;
 
+#ifdef TARGET_PC
+    if (g_pc_settings.shadow_quality == 2) {
+        return;
+    }
+#endif
     if (draw_list != NULL) {
         Vtx* vtx = (Vtx*)GRAPH_ALLOC_TYPE(graph, Vtx, draw_part->shadow_vtx_count);
 

--- a/src/bg_item/bg_item_common.c_inc
+++ b/src/bg_item/bg_item_common.c_inc
@@ -1,3 +1,7 @@
+#ifdef TARGET_PC
+#include "pc_settings.h"
+#endif
+
 static void bit_cmn_single_drawS(GAME* game, bg_item_common_info_c* common_info, mActor_name_t fg_item, xyz_t* pos,
                                  s_xyz* angle, xyz_t* scale, u8 alpha, bIT_DRAW_BF_PROC draw_bf,
                                  bIT_DRAW_AF_PROC draw_af, rgba_t* col);
@@ -2764,11 +2768,30 @@ static void bg_item_common_destruct(GAME_PLAY* play, ACTOR* actorx, bg_item_comm
 }
 
 static int bg_item_common_culling_check(GAME_PLAY* play, ACTOR* actorx, xyz_t* pos) {
-    xyz_t camera_pos;
-    f32 camera_w;
+#ifdef TARGET_PC
+    /* PC frustum_cull uses actor->player_distance_xz in Actor_draw_actor_no_culling_check2; the BG item
+     * actor is not at each instance's world position. Use distance from this draw instance to player. */
+    if (g_pc_settings.frustum_cull) {
+        PLAYER_ACTOR* player = GET_PLAYER_ACTOR(play);
 
-    Skin_Matrix_PrjMulVector(&play->projection_matrix, pos, &camera_pos, &camera_w);
-    return Actor_draw_actor_no_culling_check2(actorx, &camera_pos, camera_w);
+        if (player == NULL) {
+            return TRUE;
+        }
+        {
+            f32 d = search_position_distanceXZ(pos, &player->actor_class.world.position);
+            f32 lim = (f32)pc_settings_cull_limit_xz((float)actorx->cull_distance, (float)actorx->cull_radius);
+
+            return d <= lim;
+        }
+    }
+#endif
+    {
+        xyz_t camera_pos;
+        f32 camera_w;
+
+        Skin_Matrix_PrjMulVector(&play->projection_matrix, pos, &camera_pos, &camera_w);
+        return Actor_draw_actor_no_culling_check2(actorx, &camera_pos, camera_w);
+    }
 }
 
 static int bg_item_common_culling_check_talk(GAME_PLAY* play, ACTOR* actorx, xyz_t* pos) {

--- a/src/game/m_actor.c
+++ b/src/game/m_actor.c
@@ -20,6 +20,7 @@
 #include "m_common_data.h"
 #ifdef TARGET_PC
 #include "pc_platform.h"
+#include "pc_settings.h"
 #endif
 
 #ifdef MUST_MATCH
@@ -275,14 +276,31 @@ extern int Actor_draw_actor_no_culling_check(ACTOR* actor) {
 
 extern int Actor_draw_actor_no_culling_check2(ACTOR* actor, xyz_t* camera_pos, f32 camera_w) {
 #ifdef TARGET_PC
-    /* PC port: the GC projection matrix produced clip-space values in a range the
-     * original culling thresholds were tuned for.  The PC/OpenGL projection produces
-     * values in a different range, causing false-negative culling.  Disable software
-     * frustum culling on PC — the GPU clips out-of-frustum geometry anyway.
-     * TODO: properly recalibrate the clip-space thresholds for the PC projection. */
-    (void)camera_pos;
-    (void)camera_w;
-    return TRUE;
+    if (!g_pc_settings.frustum_cull) {
+        /* Culling disabled: original behavior — always visible */
+        (void)camera_pos;
+        (void)camera_w;
+        return TRUE;
+    }
+    /* Diagnostic: print actual clip-space values so we can calibrate the thresholds.
+     * Prints the first 5 actors encountered after enabling cull, then stops. */
+    {
+        static int s_printed = 0;
+        if (s_printed < 5) {
+            s_printed++;
+            printf("[cull] id=%d  cam_z=%.2f  cam_x=%.2f  cam_w=%.2f"
+                   "  pdist=%.1f  cull_dist=%.0f  cull_r=%.0f  cull_w=%.0f\n",
+                   actor->id, camera_pos->z, camera_pos->x, camera_w,
+                   actor->player_distance_xz,
+                   actor->cull_distance, actor->cull_radius, actor->cull_width);
+        }
+    }
+    /* World-space distance cull using player_distance_xz (already computed in call_actor).
+     * Avoids projection matrix convention uncertainty entirely. */
+    {
+        f32 z_pad = (f32)g_pc_settings.frustum_cull_z_margin;
+        return (actor->player_distance_xz <= actor->cull_distance + actor->cull_radius + z_pad);
+    }
 #else
     int res = FALSE;
 

--- a/src/game/m_actor.c
+++ b/src/game/m_actor.c
@@ -282,24 +282,11 @@ extern int Actor_draw_actor_no_culling_check2(ACTOR* actor, xyz_t* camera_pos, f
         (void)camera_w;
         return TRUE;
     }
-    /* Diagnostic: print actual clip-space values so we can calibrate the thresholds.
-     * Prints the first 5 actors encountered after enabling cull, then stops. */
+    /* World-space XZ distance vs player (see pc_settings: margin + optional max cap). */
     {
-        static int s_printed = 0;
-        if (s_printed < 5) {
-            s_printed++;
-            printf("[cull] id=%d  cam_z=%.2f  cam_x=%.2f  cam_w=%.2f"
-                   "  pdist=%.1f  cull_dist=%.0f  cull_r=%.0f  cull_w=%.0f\n",
-                   actor->id, camera_pos->z, camera_pos->x, camera_w,
-                   actor->player_distance_xz,
-                   actor->cull_distance, actor->cull_radius, actor->cull_width);
-        }
-    }
-    /* World-space distance cull using player_distance_xz (already computed in call_actor).
-     * Avoids projection matrix convention uncertainty entirely. */
-    {
-        f32 z_pad = (f32)g_pc_settings.frustum_cull_z_margin;
-        return (actor->player_distance_xz <= actor->cull_distance + actor->cull_radius + z_pad);
+        f32 lim = (f32)pc_settings_cull_limit_xz((float)actor->cull_distance, (float)actor->cull_radius);
+
+        return (actor->player_distance_xz <= lim);
     }
 #else
     int res = FALSE;

--- a/src/game/m_actor.c
+++ b/src/game/m_actor.c
@@ -266,7 +266,26 @@ static void Actor_draw(GAME_PLAY* play, ACTOR* actor) {
 
     /* Draw shadow */
     if (actor->shape_info.shadow_proc != NULL) {
+        int skip_shadow = FALSE;
+#ifdef TARGET_PC
+        {
+            int q = g_pc_settings.shadow_quality;
+
+            if (q < 0 || q > 3) {
+                q = 0;
+            }
+            if (q == 2) {
+                skip_shadow = TRUE;
+            } else if (q == 1) {
+                skip_shadow = (actor->part != ACTOR_PART_PLAYER);
+            } else if (q == 3) {
+                skip_shadow = (actor->part != ACTOR_PART_PLAYER && actor->part != ACTOR_PART_NPC);
+            }
+        }
+#endif
+        if (!skip_shadow) {
         (*actor->shape_info.shadow_proc)(actor, lights, play);
+        }
     }
 }
 

--- a/src/game/m_field_info.c
+++ b/src/game/m_field_info.c
@@ -1,5 +1,6 @@
 #include "m_field_info.h"
 
+#include "pc_settings.h"
 #include "m_scene_table.h"
 #include "m_random_field.h"
 #include "m_common_data.h"
@@ -1092,45 +1093,51 @@ extern void mFI_BGDisplayListRefresh(xyz_t wpos) {
         }
     }
 
-    mFI_WhereisInBlock(&where_bitfield, wpos);
+    if (g_pc_settings.reduce_acre_draw < 2) {
+        mFI_WhereisInBlock(&where_bitfield, wpos);
 
-    /* Check if the acres to the immediate left or right should be displayed */
-    nearest_bx = bx - 1;
-    if ((where_bitfield & 1) != 0 && mFI_BlockCheck(nearest_bx, bz)) {
-        mFI_BGDispMake(&disp_bitfield, nearest_bx, bz);
-    } else {
-        nearest_bx = bx + 1;
-        if (((where_bitfield >> 2) & 1) != 0 && mFI_BlockCheck(nearest_bx, bz)) {
-            mFI_BGDispMake(&disp_bitfield, nearest_bx, bz);
-        }
-    }
-
-    nearest_bz = bz - 1;
-    if (((where_bitfield >> 3) & 1) != 0 && mFI_BlockCheck(bx, nearest_bz)) {
-        mFI_BGDispMake(&disp_bitfield, bx, nearest_bz); /* display acre immediately above */
-
+        /* Check if the acres to the immediate left or right should be displayed */
         nearest_bx = bx - 1;
-        if ((where_bitfield & 1) != 0 && mFI_BlockCheck(nearest_bx, nearest_bz)) {
-            mFI_BGDispMake(&disp_bitfield, nearest_bx, nearest_bz); /* display acre above and to the left */
+        if ((where_bitfield & 1) != 0 && mFI_BlockCheck(nearest_bx, bz)) {
+            mFI_BGDispMake(&disp_bitfield, nearest_bx, bz);
         } else {
             nearest_bx = bx + 1;
-            if (((where_bitfield >> 2) & 1) != 0 && mFI_BlockCheck(nearest_bx, nearest_bz)) {
-                mFI_BGDispMake(&disp_bitfield, nearest_bx, nearest_bz); /* display acre above and to the right */
+            if (((where_bitfield >> 2) & 1) != 0 && mFI_BlockCheck(nearest_bx, bz)) {
+                mFI_BGDispMake(&disp_bitfield, nearest_bx, bz);
             }
         }
-    } else {
-        nearest_bz = bz + 1;
 
-        if (((where_bitfield >> 5) & 1) != 0 && mFI_BlockCheck(bx, nearest_bz)) {
-            mFI_BGDispMake(&disp_bitfield, bx, nearest_bz); /* display acre immediately below */
+        nearest_bz = bz - 1;
+        if (((where_bitfield >> 3) & 1) != 0 && mFI_BlockCheck(bx, nearest_bz)) {
+            mFI_BGDispMake(&disp_bitfield, bx, nearest_bz); /* display acre immediately above */
 
-            nearest_bx = bx - 1;
-            if ((where_bitfield & 1) != 0 && mFI_BlockCheck(nearest_bx, nearest_bz)) {
-                mFI_BGDispMake(&disp_bitfield, nearest_bx, nearest_bz); /* display acre below and to the left */
-            } else {
-                nearest_bx = bx + 1;
-                if (((where_bitfield >> 2) & 1) != 0 && mFI_BlockCheck(nearest_bx, nearest_bz)) {
-                    mFI_BGDispMake(&disp_bitfield, nearest_bx, nearest_bz); /* display acre below and to the right */
+            if (g_pc_settings.reduce_acre_draw == 0) {
+                nearest_bx = bx - 1;
+                if ((where_bitfield & 1) != 0 && mFI_BlockCheck(nearest_bx, nearest_bz)) {
+                    mFI_BGDispMake(&disp_bitfield, nearest_bx, nearest_bz); /* display acre above and to the left */
+                } else {
+                    nearest_bx = bx + 1;
+                    if (((where_bitfield >> 2) & 1) != 0 && mFI_BlockCheck(nearest_bx, nearest_bz)) {
+                        mFI_BGDispMake(&disp_bitfield, nearest_bx, nearest_bz); /* display acre above and to the right */
+                    }
+                }
+            }
+        } else {
+            nearest_bz = bz + 1;
+
+            if (((where_bitfield >> 5) & 1) != 0 && mFI_BlockCheck(bx, nearest_bz)) {
+                mFI_BGDispMake(&disp_bitfield, bx, nearest_bz); /* display acre immediately below */
+
+                if (g_pc_settings.reduce_acre_draw == 0) {
+                    nearest_bx = bx - 1;
+                    if ((where_bitfield & 1) != 0 && mFI_BlockCheck(nearest_bx, nearest_bz)) {
+                        mFI_BGDispMake(&disp_bitfield, nearest_bx, nearest_bz); /* display acre below and to the left */
+                    } else {
+                        nearest_bx = bx + 1;
+                        if (((where_bitfield >> 2) & 1) != 0 && mFI_BlockCheck(nearest_bx, nearest_bz)) {
+                            mFI_BGDispMake(&disp_bitfield, nearest_bx, nearest_bz); /* display acre below and to the right */
+                        }
+                    }
                 }
             }
         }

--- a/src/graph.c
+++ b/src/graph.c
@@ -398,7 +398,7 @@ extern void graph_proc(void* arg) {
             {
                 double ticks_per_visual;
                 int ticks, t;
-                if (g_pc_settings.fps_target == 7) {
+                if (g_pc_settings.fps_target == 6) {
                     /* Dynamic: arbitrary fps, use exact ratio (accumulator handles fractions) */
                     ticks_per_visual = (g_pc_fps_target > 0) ? 60.0 / (double)g_pc_fps_target : 1.0;
                 } else {


### PR DESCRIPTION
Adds Performance settings tab for:

- Object culling
  - Optionally attempting to render less objects outside of the player's viewport
- Acre loading
  - Load all 8 acres around current acre (default), load adjacent acres only ("cross"), or keep only the current acre loaded
- Shadows on/only player/off


Impact across these varies, but with moderate culling/loading settings I can get between 5-15 extra fps depending on what's going on