### PR TITLE
Perf: hoist loop-invariant aflags checks out of per-vertex loop

### DIFF
--- a/src/static/libforest/emu64/emu64.c
+++ b/src/static/libforest/emu64/emu64.c
@@ -4667,6 +4667,12 @@ void emu64::dl_G_VTX() {
             this->disp_matrix(position_mtx);
         }
 
+        /* Hoist loop-invariant aflags/geometry_mode checks outside the per-vertex loop */
+        const bool vtx_tex_gen = (aflags[AFLAGS_FORCE_VTX_FLAG_COPY] == 0) &&
+                                 ((this->geometry_mode & G_TEXTURE_GEN) != 0);
+        const int  normal_type  = aflags[AFLAGS_VTX_NORMAL_MODIFY_TYPE];
+        const bool do_normalize = (normal_type == 0) && ((this->geometry_mode & G_TEXTURE_GEN) != 0);
+
         while (n != 0) {
             /* Convert position */
             OSs16tof32(&vtx_p->n.ob[0], &emu_vtx_p->position.x);
@@ -4674,7 +4680,7 @@ void emu64::dl_G_VTX() {
             OSs16tof32(&vtx_p->n.ob[2], &emu_vtx_p->position.z);
 
             /* Flag */
-            if (aflags[AFLAGS_FORCE_VTX_FLAG_COPY] == 0 && (this->geometry_mode & G_TEXTURE_GEN) != 0) {
+            if (vtx_tex_gen) {
                 emu_vtx_p->flag = MTX_SHARED;
             } else {
                 emu_vtx_p->flag = vtx_p->n.flag & MTX_NONSHARED;
@@ -4690,13 +4696,13 @@ void emu64::dl_G_VTX() {
             emu_vtx_p->normal.z = fastcast_float(&vtx_p->n.n[2]);
 
             /* Check vertex normal modification type. In AC/e+ only VECNormalize is utilized. */
-            if (aflags[AFLAGS_VTX_NORMAL_MODIFY_TYPE] == 0 && (this->geometry_mode & G_TEXTURE_GEN) != 0) {
+            if (do_normalize) {
                 PSVECNormalize(&emu_vtx_p->normal, &emu_vtx_p->normal);
-            } else if (aflags[AFLAGS_VTX_NORMAL_MODIFY_TYPE] == 2) {
+            } else if (normal_type == 2) {
                 emu_vtx_p->normal.x *= (1.0f / 120.0f);
                 emu_vtx_p->normal.y *= (1.0f / 120.0f);
                 emu_vtx_p->normal.z *= (1.0f / 120.0f);
-            } else if (aflags[AFLAGS_VTX_NORMAL_MODIFY_TYPE] == 3) {
+            } else if (normal_type == 3) {
                 emu_vtx_p->normal.x *= (1.0f / 128.0f);
                 emu_vtx_p->normal.y *= (1.0f / 128.0f);
                 emu_vtx_p->normal.z *= (1.0f / 128.0f);


### PR DESCRIPTION
## Summary

- In `dl_G_VTX()` (`emu64.c`), two aflag conditions were re-evaluated on every vertex inside the `while (n != 0)` loop, despite being constant for the entire batch:
  - `aflags[AFLAGS_FORCE_VTX_FLAG_COPY] == 0 && (geometry_mode & G_TEXTURE_GEN) != 0` (vertex flag assignment)
  - `aflags[AFLAGS_VTX_NORMAL_MODIFY_TYPE]` with three branches (normal scaling / normalization)
- Both `aflags[]` (global array) and `geometry_mode` are invariant within a vertex batch, so these checks were pure repeated work — multiplied by N vertices per call, every frame.
- Fix: precompute `vtx_tex_gen`, `normal_type`, and `do_normalize` once before the loop. The loop body now reads cheap locals instead of re-indexing the global array and re-evaluating multi-part conditions each iteration.

## Test plan

- [ ] Verify rendering output is identical (no visual regressions)
- [ ] Confirm texture gen surfaces (e.g. reflective/environment-mapped objects) still render correctly
- [ ] Confirm normal scaling modes (type 2 / type 3) still apply correctly where used
