### PR TITLE
Fix segfault in net catch: u32 truncates 64-bit actor pointers

### DIFF
--- a/src/game/m_player.c
+++ b/src/game/m_player.c
@@ -348,7 +348,7 @@ static int Player_actor_request_main_fall_pitfall_all(GAME* game, int prio);
 static int Player_actor_request_main_struggle_pitfall_all(GAME* game, int prio);
 static int Player_actor_request_main_climbup_pitfall_all(GAME* game, int prio);
 static int Player_actor_request_main_notice_bee_all(GAME* game, int prio);
-static int Player_actor_request_main_notice_mosquito(GAME* game, u32 label, int prio);
+static int Player_actor_request_main_notice_mosquito(GAME* game, uintptr_t label, int prio);
 static int Player_actor_request_main_demo_geton_boat_sitdown_all(GAME* game, int prio);
 static int Player_actor_request_main_demo_geton_boat_wait_all(GAME* game, int prio);
 static int Player_actor_request_main_demo_getoff_boat_all(GAME* game, const xyz_t* pos_p, s16 angle_y, int prio);

--- a/src/game/m_player_main_notice_mosquito.c_inc
+++ b/src/game/m_player_main_notice_mosquito.c_inc
@@ -1,4 +1,4 @@
-static int Player_actor_request_main_notice_mosquito(GAME* game, u32 label, int prio) {
+static int Player_actor_request_main_notice_mosquito(GAME* game, uintptr_t label, int prio) {
     if (Player_actor_check_request_main_able(game, mPlayer_INDEX_NOTICE_MOSQUITO, prio)) {
         PLAYER_ACTOR* player = GET_PLAYER_ACTOR_GAME(game);
         mPlayer_request_notice_mosquito_c* req_notice_mosquito_p = &player->requested_main_index_data.notice_mosquito;

--- a/src/game/m_player_main_notice_net.c_inc
+++ b/src/game/m_player_main_notice_net.c_inc
@@ -20,7 +20,7 @@ static void Player_actor_setup_main_Notice_net(ACTOR* actor, GAME* game) {
     PLAYER_ACTOR* player = (PLAYER_ACTOR*)actor;
     mPlayer_main_notice_net_c* main_notice = &player->main_data.notice_net;
     mPlayer_request_notice_net_c* req_notice = &player->requested_main_index_data.notice_net;
-    u32 label;
+    uintptr_t label;
 
     main_notice->state = 0;
     main_notice->exchange_flag = FALSE;

--- a/src/game/m_player_main_swing_net.c_inc
+++ b/src/game/m_player_main_swing_net.c_inc
@@ -162,7 +162,7 @@ static int Player_actor_Item_CheckLocalCapture_forNet(const xyz_t* net_top_col, 
     return TRUE;
 }
 
-static int Player_actor_CheckCaptureForce_forNet(ACTOR* actor, u32* label_req, s8* type_req) {
+static int Player_actor_CheckCaptureForce_forNet(ACTOR* actor, uintptr_t* label_req, s8* type_req) {
     PLAYER_ACTOR* player = (PLAYER_ACTOR*)actor;
 
     if (player->item_net_catch_label_request_force != 0) {
@@ -175,10 +175,10 @@ static int Player_actor_CheckCaptureForce_forNet(ACTOR* actor, u32* label_req, s
     }
 }
 
-static int Player_actor_CheckCapture_forNet(ACTOR* actor, u32* label_req, s8* type_req) {
+static int Player_actor_CheckCapture_forNet(ACTOR* actor, uintptr_t* label_req, s8* type_req) {
     PLAYER_ACTOR* player = (PLAYER_ACTOR*)actor;
     int catch_num;
-    u32* req_label_table;
+    uintptr_t* req_label_table;
     s8* type_table;
     xyz_t* catch_pos_table;
     f32* rad_req;
@@ -240,7 +240,7 @@ static int Player_actor_CatchSomethingCheck_common(ACTOR* actor, f32 frame) {
 
     if (player->keyframe0.frame_control.current_frame > frame) {
         mPlayer_main_swing_net_c* main_swing = &player->main_data.swing_net;
-        u32 label;
+        uintptr_t label;
         s8 type;
         uintptr_t pl_label = player->item_net_catch_label;
 


### PR DESCRIPTION
On 64-bit, actor labels are uintptr_t (8 bytes) but were being stored and passed as u32 (4 bytes), silently truncating the upper 32 bits of the pointer. This caused an immediate SIGSEGV when the truncated value was cast back to an actor struct pointer and dereferenced.

Affected sites:
- Player_actor_CheckCaptureForce_forNet: parameter u32* -> uintptr_t*
- Player_actor_CheckCapture_forNet: parameter and local u32* -> uintptr_t*
- Player_actor_CatchSomethingCheck_common: local u32 -> uintptr_t
- Player_actor_setup_main_Notice_net: local u32 -> uintptr_t
- Player_actor_request_main_notice_mosquito: parameter u32 -> uintptr_t (declaration in m_player.c and definition in .c_inc)

https://claude.ai/code/session_01Ewpmj5JSx6XdavRDhiPQbX